### PR TITLE
Replaced sb-gray with trivial-gray-streams: diff now appears to at least compile on CCL

### DIFF
--- a/diff.asd
+++ b/diff.asd
@@ -6,7 +6,7 @@
 
 (defsystem :diff
   :version "0.4"
-  :depends-on (cl-ppcre)
+  :depends-on (:cl-ppcre :trivial-gray-streams)
   :components ((:file "package")
                (:file "diff" :depends-on ("package"))
                (:file "patch" :depends-on ("diff"))

--- a/vdelta.lisp
+++ b/vdelta.lisp
@@ -6,11 +6,11 @@
 (deftype bytebuf () '(simple-array (unsigned-byte 8) (*)))
 
 ;;; a convenience class for writing byte buffers
-(defclass byte-buffer-stream (sb-gray:fundamental-binary-output-stream)
+(defclass byte-buffer-stream (trivial-gray-streams:fundamental-binary-output-stream)
   ((buffer :accessor buffer :initarg :buffer :type bytebuf)
    (index :accessor index :initform 0 :type fixnum)))
 
-(defmethod sb-gray:stream-write-byte ((stream byte-buffer-stream) byte)
+(defmethod trivial-gray-streams:stream-write-byte ((stream byte-buffer-stream) byte)
   (with-slots (buffer index) stream
     (when (>= index (length buffer))
       (error "Cannot write any more data to stream!"))


### PR DESCRIPTION
There's two gray stream classes used in diff that reference an SBCL-specific class; making diff depend on trivial-gray-streams and using the equivalent classes from that library seems to work.
